### PR TITLE
Removed secondary workflow check for publishing.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,19 +32,19 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
-  publish-gpr:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+# publish-gpr:
+#   needs: build
+#   runs-on: ubuntu-latest
+#   permissions:
+#     contents: read
+#     packages: write
+#   steps:
+#     - uses: actions/checkout@v2
+#     - uses: actions/setup-node@v2
+#       with:
+#         node-version: 14
+#         registry-url: https://npm.pkg.github.com/
+#     - run: npm ci
+#     - run: npm publish
+#       env:
+#         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@OWNER:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Removed the secondary publish for the github workflow, as it's not going to be supported.